### PR TITLE
Bugfix: added wrapper <div> for global context menu hyperapp.

### DIFF
--- a/src/contextmenu.js
+++ b/src/contextmenu.js
@@ -107,6 +107,7 @@ export class ContextMenu {
     this.core = core;
     this.callback = () => {};
     this.actions = null;
+    this.$element = document.createElement('div');
   }
 
   destroy() {
@@ -119,6 +120,9 @@ export class ContextMenu {
    */
   init() {
     let clampTimeout;
+
+    this.$element.className = 'osjs-system-context-menu';
+    this.core.$root.appendChild(this.$element);
 
     this.actions = app({
       visible: false,
@@ -186,7 +190,7 @@ export class ContextMenu {
           this.callback(...args);
         }
       }
-    }), this.core.$root);
+    }), this.$element);
   }
 
   /**


### PR DESCRIPTION
Creating a hyperapp instance directly over `core.$root` is brittle.

This is because hyperapp, by default, recycles DOM elements. So some random element attached to `core.$root` may be picked up and reused for `osjs-context-menu`.

Currently this bug does not manifest since the root happens to always contain a `<script>` tag as its first child. But this is merely a coincidence. Moving the script tag somewhere else causes the menu to stop working, because (wait for it) the `Splash` app's element is picked by hyperapp to host the context menu, and this element is consequently removed when that app is destroyed.

This revision is based on the code for the `Search` app, which first creates a sub-element of `core.$root` and then passes that element to hyperapp.