### PR TITLE
Feat/contextmenu add shortcut support

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -29,6 +29,8 @@
  */
 
 $base-margin: 1em;
+$shortcut-font-size: 70%;
+$shortcut-font-color: #919699;
 
 @import "./src/styles/_common.scss";
 @import "./src/styles/_box.scss";

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -58,8 +58,14 @@ const ul = (props, children = [], level = 0) => {
       ? 'osjs-gui-menu-separator'
       : 'osjs-gui-menu-label ' + (child.disabled ? 'osjs__disabled' : '');
 
+    const innerChildren = [h('span', {}, label(child))];
+
+    if(child.shortcut) {
+      innerChildren.push(h('span', {class: 'osjs-gui-menu-shortcut'}, child.shortcut));
+    }
+
     const children = [
-      h('span', {class: className}, label(child))
+      h('span', {class: className}, innerChildren)
     ];
 
     if (child.items) {

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -121,7 +121,7 @@ const ul = (props, children = [], level = 0) => {
  * A menu
  * @param {Object} props Properties
  * @param {Boolean} [props.visible=true] Visible property
- * @param {Object} [posprops.ition] Position
+ * @param {Object} [props.position] Position
  * @param {MenuItems} [props.menu] Menu items
  */
 export const Menu = (props) => h('div', {

--- a/src/styles/_menu.scss
+++ b/src/styles/_menu.scss
@@ -105,11 +105,21 @@
   min-height: 1rem;
   align-items: center;
 
-  & > .osjs-icon {
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  gap: $base-margin / 2;
+
+  .osjs-icon {
     margin-right: $base-margin / 2;
   }
 
-  & > .osjs-gui-menu-checkbox {
+  .osjs-gui-menu-shortcut {
+    color: $shortcut-font-color;
+    font-size: $shortcut-font-size;
+  }
+
+  .osjs-gui-menu-checkbox {
     margin-right: $base-margin / 2;
 
     &::after {

--- a/src/styles/_menu.scss
+++ b/src/styles/_menu.scss
@@ -104,7 +104,6 @@
   white-space: nowrap;
   min-height: 1rem;
   align-items: center;
-
   flex-direction: row;
   flex-wrap: nowrap;
   justify-content: space-between;

--- a/src/styles/_menu.scss
+++ b/src/styles/_menu.scss
@@ -130,7 +130,7 @@
 .osjs-gui-menu-container {
   &[data-has-children] > .osjs-gui-menu-label {
     &::after {
-      content: '\25B6';
+      content: '\276f';
       position: absolute;
       right: $base-margin / 2;
       top: 50%;


### PR DESCRIPTION
### What changed
I added a new feature that allows the user to set a "shortcut" string in the context menu. This is particularly useful when the user builds an application with lots of tool-like functionalities and relies on keyboard shortcuts. This new feature allows the user to expose the shortcuts in the context menus. The screenshot below shows the feature in action:

<img width="309" alt="Screenshot 2021-11-06 at 04 22 07" src="https://user-images.githubusercontent.com/13248388/140596579-0e7e8026-765d-49a1-a537-dc6334d6a12d.png">

I also changed the menu caret for a more visually pleasing arrow.

In order to add a shortcut to the menu, add the *shortcut* property to the menu definition, as a string. Example:
```javascript
this.core.make('osjs/contextmenu').show({
  position: ev,
  menu: [{
    label: "Save File",
    shortcut: "CTRL+S"
  }]
});
```

### Further comments
- If set, the shortcut key will be displayed even when there are submenus. In this case it will be shown and right after it, there will be the caret which opens the submenu. This might not make much sense because if an action has a shortcut then it should be final and have no submenus. Therefore, we may consider forbidding the presence of a shortcut hint when the menu contains sub items.
