### PR TITLE
Added multiselect to ListView

### DIFF
--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -105,10 +105,21 @@ export const ListView = props => h(Element, Object.assign({
 
 export const listView = ({
   component: (state, actions) => {
-    // TODO: Ability to deselect with control and shift key
-    const createSelection = (index) => state.selectedIndex.indexOf(index) === -1
-      ? [...state.selectedIndex, index]
-      : state.selectedIndex;
+    const createSelection = index => {
+      if (state.multiselect) {
+        const foundIndex = state.selectedIndex.indexOf(index);
+        const newSelection = [...state.selectedIndex];
+        if (foundIndex === -1) {
+          newSelection.push(index);
+        } else {
+          newSelection.splice(foundIndex, 1);
+        }
+
+        return newSelection;
+      }
+
+      return state.selectedIndex;
+    }
 
     /**
      * Creates a range of indexes from start to end

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -118,12 +118,14 @@ export const listView = ({
      */
     const createSelectionRange = (start, end) => {
       // Swaps start and end if start is greater than end
-      if (start > end) [start, end] = [end, start];
+      if (start > end) {
+        [start, end] = [end, start];
+      }
 
       const indices = [
         ...state.selectedIndex,
         // Generates a range of indexes from start to end
-        ...Array.from({ length: end - start + 1 }, (_, i) => i + start)
+        ...Array.from({length: end - start + 1}, (_, i) => i + start)
       ];
 
       // Remove duplicates from the array
@@ -145,8 +147,11 @@ export const listView = ({
 
       // Store the previous index in the state to use for calculating the
       // range if the shift key is pressed
-      if (state.multiselect) state.previousSelectedIndex = index;
-      return { selected, data };
+      if (state.multiselect) {
+        state.previousSelectedIndex = index;
+      }
+
+      return {selected, data};
     };
 
     const clearCurrentSelection = (index) => {
@@ -156,7 +161,7 @@ export const listView = ({
         ? state.selectedIndex.map((item) => state.rows[item].data)
         : state.rows[index].data;
 
-      return { selected, data };
+      return {selected, data};
     };
 
     const newProps = Object.assign({

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -130,7 +130,7 @@ export const listView = ({
 
       // Remove duplicates from the array
       return [...new Set(indices)];
-    }
+    };
 
     const getSelection = (index, ev) => {
       const selected = state.multiselect

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -148,7 +148,7 @@ export const listView = ({
       // Store the previous index in the state to use for calculating the
       // range if the shift key is pressed
       if (state.multiselect) {
-        state.previousSelectedIndex = index;
+        actions.setPreviousSelectedIndex(index);
       }
 
       return {selected, data};
@@ -213,5 +213,6 @@ export const listView = ({
     setColumns: columns => ({columns}),
     setScrollTop: scrollTop => state => ({scrollTop}),
     setSelectedIndex: selectedIndex => ({selectedIndex}),
+    setPreviousSelectedIndex: previousSelectedIndex => ({previousSelectedIndex}),
   }, actions || {})
 });

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -119,7 +119,7 @@ export const listView = ({
       }
 
       return state.selectedIndex;
-    }
+    };
 
     /**
      * Creates a range of indexes from start to end


### PR DESCRIPTION
Adds some additional functionality to the existing #33, which is meant to close out #32.

This implementation has more feature-parity with typical desktop file manager applications in that the `ctrl` and `shift` keys now have separate useful functionality. The `ctrl` key allows for the selection of multiple individual files, whereas the `shift` key allows for a selection of a range of files.